### PR TITLE
Only download specific SDK

### DIFF
--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -87,8 +87,11 @@ jobs:
       - name: Download iOS SDK
         if: steps.SDK.outputs.cache-hit != 'true'
         run: |
-          git clone --quiet https://github.com/arichorn/sdks.git
-          mv sdks/iPhoneOS${{ inputs.sdk_version }}.sdk $THEOS/sdks
+          git clone --quiet -n --depth=1 --filter=tree:0 https://github.com/arichorn/sdks/
+          cd sdks
+          git sparse-checkout set --no-cone iPhoneOS${{ inputs.sdk_version }}.sdk
+          git checkout
+          mv *.sdk $THEOS/sdks
         env:
           THEOS: ${{ github.workspace }}/theos
 


### PR DESCRIPTION
I was working on a fix for the removal of subversion from github workflows, and then I saw that one was already implemented.
This version, based on https://stackoverflow.com/questions/600079/how-do-i-clone-a-subdirectory-only-of-a-git-repository/52269934#52269934 only downloads the specific SDK